### PR TITLE
Update README.md: Added command for building docker image on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,12 @@ Make sure Docker Desktop is running, then run:
 docker build -t ping-pong-game .
 ```
 
+For Macs with Apple Silicon (M series chips), Docker image is built for arm64, but the AWS Fargate expects x86_64 (Intel/AMD architecture)
+Add --platform=linux/amd64 in the Docker build command.
+
+```bash
+docker build --platform=linux/amd64 -t ping-pong-game .
+```
 ---
 
 #### 🏷7.4 Tag the Docker Image for ECR


### PR DESCRIPTION
AWS Fargate required a Docker image for linux/amd64 platform.

If the Docker image is built on Macs with Apple Silicon, it is built for the arm architecture, which causes failure after deployment.

Hence, added the command to build the image for the linux/amd64. 

Please merge these changes, so Mac users won't face issues in building this project.